### PR TITLE
Fast adc

### DIFF
--- a/firmware/src/adc.h
+++ b/firmware/src/adc.h
@@ -23,30 +23,23 @@
 // Note the resolution. For example.. at 150hz, ICR1 = PWM_TOP = 159, so it
 //#define QUOTIENT  (((uint32_t)MACHINE_TIMER_PRESCALER)*((uint32_t)MACHINE_TIMER_FREQUENCY))
 //#define ADC_TIMER_TOP (0.5*(F_CPU)/QUOTIENT)
-#define ADC_TIMER_FREQUENCY     ((uint32_t)(ADC_FREQUENCY)*(uint8_t)(ADC_LAST_CHANNEL +1))
+#define ADC_TIMER_FREQUENCY     ((uint32_t)(ADC_FREQUENCY))
 #define ADC_TIMER_TOP           ((F_CPU/(2*ADC_TIMER_PRESCALER))/(ADC_TIMER_FREQUENCY) -1)
 
-typedef enum adc_channels{ 
-    ADC0, ADC1 ,ADC2, ADC3, ADC4, ADC5
-} adc_channels_t;                           //*< the adc_channel type 
-
-#define ADC_LAST_CHANNEL ADC0
-
-typedef struct{
-    uint32_t sum;
-    uint16_t avg;
-} adc_channel_t;
+typedef struct _adc{
+    uint64_t sum;
+    uint16_t samples;
+    uint8_t ready;
+} _adc_t;
 
 typedef struct adc{
-    adc_channel_t channel[ADC_LAST_CHANNEL+1];
-    adc_channels_t select;
-    uint16_t samples;
+    uint64_t value;
     uint8_t ready;
 } adc_t;
 
-volatile adc_t adc;
+static volatile _adc_t adc;
+volatile adc_t adc0;
 
-uint8_t adc_select_channel(adc_channels_t __ch);
 void adc_init(void);
 
 #endif /* ifndef _ADC_H_ */

--- a/firmware/src/conf.h
+++ b/firmware/src/conf.h
@@ -27,7 +27,7 @@
 
 // MODULES ACTIVATION
 #define USART_ON
-#define CAN_ON
+//#define CAN_ON
 //#define CAN_DEPENDENT
 #define ADC_ON
 #define MACHINE_ON
@@ -39,13 +39,10 @@
 #ifdef ADC_ON
 // ADC CONFIGURATION
 // note that changing ADC_FREQUENCY may cause problems with avg_sum_samples
-#define ADC_FREQUENCY                       10000 // 20000
+#define ADC_FREQUENCY                       500000
 #define ADC_TIMER_PRESCALER                 8
-#define ADC0_AVG                            adc.channel[ADC0].avg
-#define ADC0_ANGULAR_COEF                   10000 //(40000/((4/5)*1024))
-#define ADC0_LINEAR_COEF                    0
-#define ADC_AVG_SIZE_2                      7                  // in base 2
-#define ADC_AVG_SIZE_10                     128                // in base 10
+#define ADC_AVG_SIZE_2                      10                  // in base 2
+#define ADC_AVG_SIZE_10                     4096                // in base 10
 
 //#define FAKE_ADC_ON
 #ifdef FAKE_ADC_ON
@@ -57,7 +54,7 @@
 
 #ifdef MACHINE_ON
 // The machine frequency may not be superior of ADC_FREQUENCY/ADC_AVG_SIZE_10
-#define MACHINE_TIMER_FREQUENCY             300           //<! machine timer frequency in Hz
+#define MACHINE_TIMER_FREQUENCY             1000           //<! machine timer frequency in Hz
 #define MACHINE_TIMER_PRESCALER             1024          //<! machine timer prescaler
 #define MACHINE_CLK_DIVIDER_VALUE           ((uint64_t)(uint32_t)MACHINE_TIMER_FREQUENCY*(uint32_t)ADC_AVG_SIZE_10)/(ADC_FREQUENCY)           //<! machine_run clock divider
 #define MACHINE_FREQUENCY                   (MACHINE_TIMER_FREQUENCY)/(MACHINE_CLK_DIVIDER_VALUE)

--- a/firmware/src/machine.h
+++ b/firmware/src/machine.h
@@ -13,6 +13,8 @@
 #include <avr/io.h>
 #include <avr/wdt.h>
 #include <avr/interrupt.h>
+#include <avr/sleep.h>
+#include <math.h>
 
 #include "conf.h"
 
@@ -56,13 +58,14 @@ typedef union error_flags{
 }error_flags_t;
 
 typedef struct measurements{
-    uint16_t    adc0_avg;       // average value of ADC0
+    uint32_t    adc0_avg;       // average value of ADC0
     uint16_t    adc0_avg_sum_count;
     uint64_t    adc0_avg_sum;   // average value of ADC0
     uint16_t    adc0_min;       // period minimum value of ADC0
     uint16_t    adc0_max;       // period maximum value of ADC0
 }measurements_t;
 
+void compute_adc0_avg(void);
 
 // machine checks
 void check_buffers(void);

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -4,9 +4,10 @@
 
 void init(void)
 {
+    cli();
 
     #ifdef USART_ON
-        usart_init(MYUBRR,1,1);                         // inicializa a usart
+        usart_init(MYUBRR,0,1);                         // inicializa a usart
         VERBOSE_MSG_INIT(usart_send_string("\n\n\nUSART... OK!\n"));
     #endif
 
@@ -40,6 +41,7 @@ void init(void)
         VERBOSE_MSG_INIT(usart_send_string("CAN filters..."));
         can_static_filter(can_filter);
         VERBOSE_MSG_INIT(usart_send_string(" OK!\n"));
+        cli();
     #else
         VERBOSE_MSG_INIT(usart_send_string("CAN... OFF!\n"));
     #endif
@@ -107,7 +109,7 @@ int main(void)
 {
     init();
    
-	for(;;){
+	for(;;){       
 		#ifdef WATCHDOG_ON
             wdt_reset();
 		#endif
@@ -121,7 +123,6 @@ int main(void)
 		#endif
 	}
 }
-
 
 /**
  * @brief se em debug, fica chaveando os pinos de debugs até o reset do watchdog
@@ -140,4 +141,3 @@ ISR(BADISR_vect)
         #endif
     }
 }
-

--- a/firmware/src/sleep.h
+++ b/firmware/src/sleep.h
@@ -17,7 +17,7 @@
 
 void sleep_init(void)
 {
-	set_sleep_mode(SLEEP_MODE_IDLE);
+	set_sleep_mode(SLEEP_MODE_ADC);
 }
 
 #endif /* ifndef SLEEP_H */

--- a/firmware/src/usart.c
+++ b/firmware/src/usart.c
@@ -1,6 +1,28 @@
 #include "usart.h"
 
 /**
+ * @brief starts the usart.
+ * @param ubrr is the baudrate
+ * @param rx enables the receive
+ * @param tx enables the transmit
+ * it is recommended to use the following defines:
+ * @code
+ *      #define USART_BAUD 9600
+ *      #define MYUBRR F_CPU/16/USART_BAUD-1
+ *      usart_init(MYUBRR,1,1);
+ * @endcode
+ */
+inline void usart_init(uint16_t ubrr, uint8_t rx, uint8_t tx)
+{
+    // set BAUDRATE
+    UBRR0H = (uint8_t)(ubrr >>8);
+    UBRR0L = (uint8_t)ubrr;
+    
+    // Enable RX and TX
+    UCSR0B = ((rx&1)<<RXEN0) | ((tx&1)<<TXEN0);
+}
+
+/**
  * @brief sends a char through serial
  * @param data will be sent trough serial
  */
@@ -30,11 +52,20 @@ inline void usart_send_string(const char *s)
 }
 
 /**
-* @brief sends a number in ascii trough serial.
-* The number could be represent with left-filled with a defined FILL char in 
-* a defined BASE. Note that the LEN is 6 because 2^16 have its maximum ascii
-* size represented with 5 chars + '\0' in the end.
-*/
+ * @brief sends a buffer through serial. Max lenght is 255.
+ */
+inline void usart_send_buffer(uint8_t *b, uint8_t lenght)
+{
+    uint8_t i = 0;
+    while(i < lenght) usart_send_char(b[i++]);
+}
+
+/**
+ * @brief sends a number in ascii trough serial.
+ * The number could be represent with left-filled with a defined FILL char in 
+ * a defined BASE. Note that the LEN is 6 because 2^16 have its maximum ascii
+ * size represented with 5 chars + '\0' in the end.
+ */
 inline void usart_send_uint8(uint8_t num)
 {
     #define LEN      4              // length of the string w/ null terminator
@@ -192,35 +223,59 @@ inline void usart_send_int32(int32_t num)
     #undef BASE
     #undef FILL    
 }
- 
-/**
- * @brief sends a buffer through serial. Max lenght is 255.
- */
-inline void usart_send_buffer(uint8_t *b, uint8_t lenght)
-{
-    uint8_t i = 0;
-    while(i < lenght) usart_send_char(b[i++]);
-}
 
 /**
- * @brief starts the usart.
- * @param ubrr is the baudrate
- * @param rx enables the receive
- * @param tx enables the transmit
- * it is recommended to use the following defines:
- * @code
- *      #define USART_BAUD 9600
- *      #define MYUBRR F_CPU/16/USART_BAUD-1
- *      usart_init(MYUBRR,1,1);
- * @endcode
+ * @brief sends a number in ascii trough serial.
+ * The number could be represent with left-filled with a defined FILL char in 
+ * a defined BASE. Note that the LEN is 11 because 2^64 have its maximum ascii
+ * size represented with 10 chars + '\0' in the end.
  */
-inline void usart_init(uint16_t ubrr, uint8_t rx, uint8_t tx)
+inline void usart_send_uint64(uint64_t num)
 {
-    // set BAUDRATE
-    UBRR0H = (uint8_t)(ubrr >>8);
-    UBRR0L = (uint8_t)ubrr;
+    #define LEN     21              // length of the string w/ null terminator
+    #define BASE    10              // string as a decimal base
+    #define FILL    '0'             // character to fill non-used algarisms.
     
-    // Enable RX and TX
-    UCSR0B = ((rx&1)<<RXEN0) | ((tx&1)<<TXEN0);
+    uint8_t i = LEN -1;             // index for each char of the string
+    char str[LEN] = {FILL};         // ascii zero filled array
+    str[i] = '\0';                  // adds string null terminator
+    while(i--){
+        str[i] = FILL + (num % BASE);// gets each algarism}
+        num /= BASE;                // prepare the next
+    }
+    usart_send_string(str);       // sends the string
+    
+    #undef LEN
+    #undef BASE
+    #undef FILL
 }
 
+inline void usart_send_int64(int64_t num)
+{
+    #define LEN     22              // length of the string w/ null terminator
+    #define BASE    10              // string as a decimal base
+    #define FILL    '0'             // character to fill non-used algarisms.
+    
+    uint8_t i = LEN -1;             // index for each char of the string
+    char str[LEN] = {FILL};         // ascii zero filled array
+    char sign = ' ';
+
+    if(num < 0){
+        sign = '-';
+        num = -num;
+    }
+
+    str[i] = '\0';                  // adds string null terminator
+    while(i--){
+        str[i] = FILL + (num % BASE);// gets each algarism}
+        num /= BASE;                // prepare the next
+    }
+
+    str[0] = sign;
+
+    usart_send_string(str);         // sends the string
+    
+    #undef LEN
+    #undef BASE
+    #undef FILL    
+}

--- a/firmware/src/usart.h
+++ b/firmware/src/usart.h
@@ -39,7 +39,7 @@ void usart_send_uint16(uint16_t num);
 void usart_send_int32(int32_t num);
 void usart_send_uint32(uint32_t num);
 
-void usart_send_int64(int32_t num);
-void usart_send_uint64(uint32_t num);
+void usart_send_int64(int64_t num);
+void usart_send_uint64(uint64_t num);
 
 #endif /* ifndef USART_H */

--- a/firmware/src/usart.h
+++ b/firmware/src/usart.h
@@ -16,18 +16,19 @@
 #include "conf.h"
 
 #ifndef USART_BAUD
-#define USART_BAUD 57600
+#define USART_BAUD 9600
 #endif /* ifndef USART_BAUD */
 #define MYUBRR F_CPU/16/USART_BAUD-1
 
 #define   USART_HAS_DATA   bit_is_set(UCSR0A, RXC0)
 #define   USART_READY      bit_is_set(UCSR0A, UDRE0)
 
+void usart_init(uint16_t ubrr, uint8_t rx, uint8_t tx);
+
 void usart_send_char(char data);
-
 char usart_receive_char(void);
-
 void usart_send_string(const char *s);
+void usart_send_buffer(uint8_t *b, uint8_t lenght);
 
 void usart_send_int8(int8_t num);
 void usart_send_uint8(uint8_t num);
@@ -38,8 +39,7 @@ void usart_send_uint16(uint16_t num);
 void usart_send_int32(int32_t num);
 void usart_send_uint32(uint32_t num);
 
-void usart_send_buffer(uint8_t *b, uint8_t lenght);
+void usart_send_int64(int32_t num);
+void usart_send_uint64(uint32_t num);
 
-void usart_init(uint16_t ubrr, uint8_t rx, uint8_t tx);
-
-#endif
+#endif /* ifndef USART_H */


### PR DESCRIPTION
Aqui está a versão com o adc rápido, usando um oversampling de pelo menos 6 bits para nosso adc. Não sei dizer até onde isso realmente adiciona precisão, preciso ainda fazer um teste com uma tensão de referência bem estável, e também comparar os valores com um voltímetro de alta precisão.

Algumas mudanças necessárias para aumentar a frequência foram:
1) aumentar também a frequência do módulo machine;
2) transferir a computação da média do adc (que antes ocorria no próprio isr do adc) para o módulo machine;
3) reduzir o baud-rate da usart para que ele consiga cumprir a temporização mesmo com as milhares de interrupções do adc.

Para tentar melhorar o nível sinal-ruído do adc, apliquei também a técnica de 'noise reduction' utilizando o sleep no modo adc. Não consegui perceber diferenças, mais testes precisam ser feitos. Até mesmo não tenho certeza se ele está em sleep na maior parte dos adcs por conta da interrupção do timer do machine. Talvez uma opção em relação à isso seria remover este timer e fazer com que o machine rode de acordo com um divisor de clock do próprio timer do adc, mas pode resultar em uma janela com pouco tempo disponível para o processamento.

Nota que por estar testando num arduino, desabilitei o canbus.

É importante notar que agora tem 500 mil interrupções por segundo ocorrendo, então talvez na hora de enviar os dados pelo canbus tenhamos que realizar atomicamente desabilitando as interrupções naquela parte.